### PR TITLE
Fix so custom fields always show - HTML admin formatting

### DIFF
--- a/Menu.php
+++ b/Menu.php
@@ -35,6 +35,17 @@ class Menu {
 	 *  @var array
 	 */
 	public static $custom_fields = array();
+	
+	/**
+	 * Maximum depth in menu to add custom fields.
+	 *
+	 * Zero-based, so 0 will add custom fields to the
+	 * top menu items only while 1 will add them to the
+	 * top 2 levels of the hierarchy.
+	 *
+	 *  @var integer
+	 */
+	public static $max_depth = \PHP_INT_MAX;
 
 	/**
 	 * Menu Management, sets navigation items custom options.
@@ -42,12 +53,21 @@ class Menu {
 	 * @since 0.1.0
 	 *
 	 * @uses add_action()
+	 * @uses add_filter()
+	 *
+	 * @param array $custom_fields Specifies the custom fields to be added.
+	 *
+	 * @param mixed $max_depth Specifies the zero-based depth in the menu to which custom fields will be added.  Non-numeric values for this parameter specify that custom fields should be added to all menu items.
 	 *
 	 * @return void
 	 */
-	function __construct( $custom_fields ) {
+	function __construct( $custom_fields, $max_depth = null ) {
 
 		self::$custom_fields = $custom_fields;
+		
+		self::$max_depth = is_numeric( $max_depth )
+			? intval( $max_depth )
+			: \PHP_INT_MAX;
 
 		add_filter( 'wp_edit_nav_menu_walker', array( $this, 'edit_nav_menu_walker' ) );
 		add_action( 'wp_update_nav_menu_item', array( $this, 'update_nav_menu_item' ), 10, 3 );

--- a/Menu_Walker_Edit.php
+++ b/Menu_Walker_Edit.php
@@ -52,12 +52,9 @@ class Lucymtc_Menu_Walker_Edit extends Walker_Nav_Menu_Edit {
 		// Get the fieldset in the list element.
 		// @todo need to make sure is the correct fieldset by class. No risk now as there is only one.
 		$fieldset = $li->item( 0 )->getElementsByTagName( 'fieldset' );
-		// Get the firs element of the fieldset, in this case it's a span.
-		// @todo get first element independently of the tag.
-		$in_fieldset = $fieldset->item( 0 )->getElementsByTagName( 'span' );
 		// Create an element as a wrapper for the fields.
-		$custom_fields_wrapper = $dom->createElement( 'div' );
-		$custom_fields_wrapper->setAttribute( 'class', 'menu_custom_fields' );
+		$custom_fields_wrapper = $dom->createElement( 'fieldset' );
+		$custom_fields_wrapper->setAttribute( 'class', 'fields-custom description description-wide' );
 
 		foreach ( $custom_fields as $field_key => $field ) {
 
@@ -69,7 +66,6 @@ class Lucymtc_Menu_Walker_Edit extends Walker_Nav_Menu_Edit {
 			}
 
 			$field_wrapper = $dom->createElement( 'p' );
-			$field_wrapper->setAttribute( 'class', 'description-wide' );
 
 			// Create the label and input elements.
 			$label = $dom->createElement( 'label', esc_html( $field['label'] ) );
@@ -82,6 +78,9 @@ class Lucymtc_Menu_Walker_Edit extends Walker_Nav_Menu_Edit {
 			// Set the atrributes.
 			if ( isset( $field['attrs'] ) ) {
 				foreach ( $field['attrs'] as $attr_key => $attr_value ) {
+					if ( $attr_key === 'class' ) {
+						$attr_value = ( ! empty( $attr_value ) ) ? sanitize_html_class( $field_key ) . ' ' . $attr_value : '';
+					}
 					$input->setAttribute( $attr_key, $attr_value );
 				}
 			}
@@ -103,8 +102,8 @@ class Lucymtc_Menu_Walker_Edit extends Walker_Nav_Menu_Edit {
 			$custom_fields_wrapper->appendChild( $field_wrapper );
 		}
 
-		// Intert it at the beginng of the fieldset.
-		$in_fieldset->item( 0 )->parentNode->insertBefore( $custom_fields_wrapper, $in_fieldset->item( 0 ) );
+		// Insert it at the beginng of the fieldset.
+		$fieldset->item( 0 )->parentNode->insertBefore( $custom_fields_wrapper, $fieldset->item( 0 ) );
 
 		$output = $dom->saveHTML();
 

--- a/Menu_Walker_Edit.php
+++ b/Menu_Walker_Edit.php
@@ -104,6 +104,11 @@ class Lucymtc_Menu_Walker_Edit extends Walker_Nav_Menu_Edit {
 
 		// Insert it at the beginng of the fieldset.
 		$fieldset->item( 0 )->parentNode->insertBefore( $custom_fields_wrapper, $fieldset->item( 0 ) );
+		
+		// The Walker_Nav_Menu_Edit parent generates TAB characters in some of the href attributes.  Processing this HTML with DOMDocument has been URL encoding embedded and trailing TAB characters to %09.  The trailing %09 breaks some of the javascript handlers on these links, so remove any TAB characters that are in the links.
+		foreach ($xpath->query('//a/@href') as $url) {
+			$url->value = trim(str_replace("\t", '', $url->value));
+		}
 
 		$output = $dom->saveHTML();
 

--- a/Menu_Walker_Edit.php
+++ b/Menu_Walker_Edit.php
@@ -21,7 +21,7 @@ class Lucymtc_Menu_Walker_Edit extends Walker_Nav_Menu_Edit {
 
 		// Prevent using LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD as support deppends on Libxml version.
 		// Wrapping the output in a container div.
-		$dom->loadHTML( mb_convert_encoding( '<div>' . $output . '</div>', 'HTML-ENTITIES', 'UTF-8' ) );
+		$dom->loadHTML( mb_convert_encoding( '<div>' . $output . '</div>', 'HTML-ENTITIES', 'UTF-8' ), LIBXML_NONET );
 		// Remove this container from the document, DOMElement of it still exists.
 		$container = $dom->getElementsByTagName( 'div' )->item( 0 );
 		$container = $container->parentNode->removeChild( $container );

--- a/Menu_Walker_Edit.php
+++ b/Menu_Walker_Edit.php
@@ -11,6 +11,10 @@ class Lucymtc_Menu_Walker_Edit extends Walker_Nav_Menu_Edit {
 	function start_el( &$output, $item, $depth = 0, $args = array(), $id = 0 ) {
 
 		parent::start_el( $output, $item, $depth, $args, $id );
+		
+		if ( $depth > \Lucymtc\Menu::$max_depth ) {
+			return;
+		}
 
 		$custom_fields = \Lucymtc\Menu::$custom_fields;
 


### PR DESCRIPTION
Here are a summary of the modifications:

* Modify output so custom fields show when only one nav menu item is …
* Update nav menu item HTML output in admin for continuity.
* Correct minor typographical errors in comments.

Great work, by the way. Saved me several hours. Thanks!